### PR TITLE
fix: sdk-5221 correct ios release workflows

### DIFF
--- a/.github/workflows/deploy-cocoapods.yml
+++ b/.github/workflows/deploy-cocoapods.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   build:
     name: Deploy to Cocoapods
+    if: startsWith(github.event.release.tag_name, 'v')
     runs-on: macOS-latest
     steps:
     - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           source_branch_name=${GITHUB_REF##*/}
           release_type=release
-          git fetch origin master --depth=1
+          git fetch origin master
           git merge origin/master
           current_version=$(jq -r .version package.json)
 

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   release:
     permissions:
-      contents: read # GITHUB_TOKEN only needs read for checkout
+      contents: read  # GitHub App token handles release writes
     name: Publish new release
     runs-on: ubuntu-latest
     if: startsWith(github.event.pull_request.head.ref, 'release/') && github.event.pull_request.merged == true # only merged pull requests must trigger this job
@@ -39,25 +39,24 @@ jobs:
           VERSION="${BRANCH_NAME#release/}"
           echo "release_version=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Checkout source branch
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
-        with:
-          token: ${{ steps.generate-token.outputs.token }}
-          fetch-depth: 0
-
-      - name: Set Node 16
-        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
-        with:
-          node-version: 16
-
-      - name: Create Github Release
-        id: create_release
+      - name: Publish GitHub release
         env:
-          HUSKY: 0
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-          CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          VERSION: ${{ steps.extract-version.outputs.release_version }}
         run: |
-          npx conventional-github-releaser -p angular
+          TAG="v${VERSION}"
+
+          if gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "Release $TAG already exists; nothing to publish."
+            exit 0
+          fi
+
+          gh release create "$TAG" \
+            --repo "${{ github.repository }}" \
+            --verify-tag \
+            --title "$TAG" \
+            --generate-notes \
+            --latest
 
       - name: Delete release branch
         uses: koj-co/delete-merged-action@63a03c35810a8a7d4840d18793c0f68ff8b59450 # master

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -64,4 +64,4 @@ jobs:
         with:
           branches: 'release/*'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
## Summary

- fetch the complete base-branch history before calculating the next version
- publish one idempotent GitHub release for the existing `v${VERSION}` tag with generated notes
- deploy to CocoaPods only for `v`-prefixed release tags

## Validation

- `actionlint` v1.7.12 passes for all three modified workflows
- the shared SDK-5074 `standard-version` fixture confirms shallow history calculates the wrong patch version and omits earlier commits

Linear: https://linear.app/rudderstack/issue/SDK-5221
Parent: https://linear.app/rudderstack/issue/SDK-5074